### PR TITLE
Feature/multi secretary

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,7 +1,18 @@
 from django.contrib import admin
+from django.contrib.auth.admin import GroupAdmin
+from django.contrib.auth.models import Group
 
 from .models import Setting
 
+admin.site.unregister(Group)
+
+class UserInLine(admin.TabularInline):
+    model = Group.user_set.through
+    extra = 0
+
+@admin.register(Group)
+class GenericGroup(GroupAdmin):
+    inlines = [UserInLine]
 
 @admin.register(Setting)
 class SettingAdmin(admin.ModelAdmin):

--- a/core/fixtures/groups.json
+++ b/core/fixtures/groups.json
@@ -22,5 +22,13 @@
         },
         "model": "auth.group",
         "pk": 3
+    },
+    {
+        "fields": {
+            "name": "Primaire secretaris",
+            "permissions": []
+        },
+        "model": "auth.group",
+        "pk": 4
     }
 ]

--- a/core/utils.py
+++ b/core/utils.py
@@ -20,7 +20,7 @@ def get_secretary():
     """
     Returns the Head secretary. We limit this to one user.
     """
-    obj = get_all_secretaries().first()
+    obj = get_user_model().objects.filter(groups__name=settings.GROUP_PRIMARY_SECRETARY).first()
     obj.email = settings.EMAIL_FROM
     return obj
 
@@ -28,7 +28,7 @@ def get_all_secretaries():
     """
     Return all users in the 'Secretary' group.
     """
-    return get_user_model().objects.filter(groups__name=settings.GROUP_PRIMARY_SECRETARY).all()
+    return get_user_model().objects.filter(groups__name=settings.GROUP_SECRETARY).all()
 
 def is_secretary(user):
     """

--- a/core/utils.py
+++ b/core/utils.py
@@ -18,16 +18,21 @@ class AvailableURL(object):
 
 def get_secretary():
     """
-    Returns the Secretary. We limit this to one user.
+    Returns the Head secretary. We limit this to one user.
     """
-    obj = get_user_model().objects.filter(groups__name=settings.GROUP_HEAD_SECRETARY).first()
+    obj = get_all_secretaries().first()
     obj.email = settings.EMAIL_FROM
     return obj
 
+def get_all_secretaries():
+    """
+    Return all users in the 'Secretary' group.
+    """
+    return get_user_model().objects.filter(groups__name=settings.GROUP_HEAD_SECRETARY).all()
 
 def is_secretary(user):
     """
-    Check whether the current user is in the 'Secretary' group
+    Check whether the current user is in the 'Secretary' group.
     """
     return Group.objects.get(name=settings.GROUP_SECRETARY) in user.groups.all()
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -28,7 +28,7 @@ def get_all_secretaries():
     """
     Return all users in the 'Secretary' group.
     """
-    return get_user_model().objects.filter(groups__name=settings.GROUP_HEAD_SECRETARY).all()
+    return get_user_model().objects.filter(groups__name=settings.GROUP_PRIMARY_SECRETARY).all()
 
 def is_secretary(user):
     """

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 import django.utils.six as six
@@ -21,6 +22,12 @@ def get_secretary():
     """
     return get_user_model().objects.filter(groups__name=settings.GROUP_SECRETARY)[0]
 
+
+def is_secretary(user):
+    """
+    Check whether the current user is in the 'Secretary' group
+    """
+    return Group.objects.get(name=settings.GROUP_SECRETARY) in user.groups.all()
 
 def get_reviewers():
     return get_user_model().objects.filter(

--- a/core/utils.py
+++ b/core/utils.py
@@ -20,7 +20,9 @@ def get_secretary():
     """
     Returns the Secretary. We limit this to one user.
     """
-    return get_user_model().objects.filter(groups__name=settings.GROUP_SECRETARY)[0]
+    obj = get_user_model().objects.filter(groups__name=settings.GROUP_HEAD_SECRETARY).first()
+    obj.email = settings.EMAIL_FROM
+    return obj
 
 
 def is_secretary(user):

--- a/fetc/settings.py
+++ b/fetc/settings.py
@@ -138,6 +138,7 @@ EMAIL_LOCAL_STAFF = 'T.D.Mees@uu.nl'
 
 # Group names
 GROUP_SECRETARY = 'Secretaris'
+GROUP_HEAD_SECRETARY = 'Eerste secretaris'
 GROUP_LINGUISTICS_CHAMBER = 'LK'
 GROUP_GENERAL_CHAMBER = 'AK'
 

--- a/fetc/settings.py
+++ b/fetc/settings.py
@@ -138,7 +138,7 @@ EMAIL_LOCAL_STAFF = 'T.D.Mees@uu.nl'
 
 # Group names
 GROUP_SECRETARY = 'Secretaris'
-GROUP_HEAD_SECRETARY = 'Eerste secretaris'
+GROUP_PRIMARY_SECRETARY = 'Primaire secretaris'
 GROUP_LINGUISTICS_CHAMBER = 'LK'
 GROUP_GENERAL_CHAMBER = 'AK'
 

--- a/reviews/mixins.py
+++ b/reviews/mixins.py
@@ -1,9 +1,12 @@
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.exceptions import PermissionDenied
 from django.utils.functional import cached_property
+from django.utils.translation import ugettext as _
 from django.views.generic.base import ContextMixin
 from django.views.generic.detail import SingleObjectMixin
-from django.utils.translation import ugettext as _
+
+from core.utils import get_all_secretaries, is_secretary
 
 from .models import Decision, Review
 from .utils import auto_review
@@ -16,18 +19,25 @@ class UserAllowedMixin(SingleObjectMixin):
         as well as whether the Review is still open.
         """
         obj = super(UserAllowedMixin, self).get_object(queryset)
+        current_user = self.request.user
 
         if isinstance(obj, Review):
-            if not obj.decision_set.filter(reviewer=self.request.user):
+            secretary_reviewers = obj.decision_set.filter(reviewer__groups__name=settings.GROUP_SECRETARY)
+            if secretary_reviewers and is_secretary(current_user):
+                return obj
+            if not obj.decision_set.filter(reviewer=current_user):
                 raise PermissionDenied
 
         if isinstance(obj, Decision):
             reviewer = obj.reviewer
             date_end = obj.review.date_end
 
-            if self.request.user != reviewer or date_end:
+            if date_end:
                 raise PermissionDenied
-
+            if ( self.request.user != reviewer ) and \
+                not ( is_secretary(reviewer) and is_secretary(current_user) ):
+                    raise PermissionDenied
+                
         return obj
 
 

--- a/reviews/mixins.py
+++ b/reviews/mixins.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext as _
 from django.views.generic.base import ContextMixin
 from django.views.generic.detail import SingleObjectMixin
 
-from core.utils import get_all_secretaries, is_secretary
+from core.utils import is_secretary
 
 from .models import Decision, Review
 from .utils import auto_review


### PR DESCRIPTION
Allows for multiple users in the 'Secretaris' group. They can edit and view each-others reviews and decisions. It's hacky, but it works (I believe).

Implemented as an additional group for the primary secretary (please suggest a better name if you can think of it). This is much simpler than making an additional group for extra secretaries, as most infrastructure remains intact.

Additionally overwrites the get_secretary() email field by the general email address.