### PR TITLE
Bugfix for missing METC decision file

### DIFF
--- a/proposals/templates/proposals/proposal_pdf.html
+++ b/proposals/templates/proposals/proposal_pdf.html
@@ -163,9 +163,14 @@ Page <pdf:pagenumber /> of <pdf:pagecount />
             <tr>
                 <th>{% get_verbose_field_name "proposals" "wmo" "metc_decision" %}</th><td>{{ wmo.metc_decision|yesno:_("ja,nee") }}</td>
             </tr>
-            {% if not proposal.is_practice %}
+            {% if wmo.metc_decision_pdf and not proposal.is_practice %}
             <tr>
                 <th>{% get_verbose_field_name "proposals" "wmo" "metc_decision_pdf" %}</th><td><a href="{{ BASE_URL }}{{ wmo.metc_decision_pdf.url }}" target="_blank">{% trans "Download" %}</a></td>
+            </tr>
+            {% else %}
+            <tr>
+                <th>{% get_verbose_field_name "proposals" "wmo" "metc_decision_pdf" %}</th>
+                    <td>{% trans "Niet aangeleverd" %}</td>
             </tr>
             {% endif %}
         </table>


### PR DESCRIPTION
It is currently possible to submit an METC-positive study without an METC decision PDF. When this happens, an error occurs in PDF generation and the user cannot continue. Modifying the proposal PDF template with a conditional fixes this.