### PR TITLE
Added paragraph in template

### DIFF
--- a/proposals/templates/proposals/study_consent.html
+++ b/proposals/templates/proposals/study_consent.html
@@ -74,6 +74,18 @@
                     kunt u weer weg halen door alle formulieren te wissen.
                 {% endblocktrans %}
             </p>
+
+            <h3>
+                {% trans "Wijzigingen bijhouden" %}
+            </h3>
+            <p>
+                {% blocktrans %}
+                    
+
+    Indien je een document moet wijzigen voor een revisie vragen wij je om 'Track changes' aan te zetten, of een apart bestand bij te voegen met de wijzigingen onder 'Extra documenten'. Op deze manier zijn wijzigingen duidelijker voor beoordelaars, en kan uw voorstel sneller beoordeeld worden.<br><b>Tip:</b> Zet 'Track changes' aan voordat u de eerste versie uploadt, zo kunt u dit later niet vergeten. 
+
+                {% endblocktrans %}
+            </p>
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
                 {{ formset.management_form }}
 


### PR DESCRIPTION
This is the current state of things:

![image](https://user-images.githubusercontent.com/7064137/105342178-5910b080-5be0-11eb-9115-784c6117bc87.png)

At first I considered only adding this paragraph if the proposal was a revision. However I feel that if a submitter got their proposal back for revision they would only see this page right when they were ready to upload it, at which point it would be of little use. The same goes for my "tip". I also fleshed out the text to fill it up.

Comments welcome