### PR TITLE
Target UiL Core v1.1 stable + updated dependencies

### DIFF
--- a/main/templates/base/site_html_head.html
+++ b/main/templates/base/site_html_head.html
@@ -1,7 +1,4 @@
 {% load static %}
-<link rel="stylesheet" type="text/css" href="//code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">
-<script type="text/javascript" charset="utf8" src="//code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-
 <link rel="stylesheet" type="text/css" href="{% static 'main/style.css' %}">
 
 <script type="text/javascript" charset="utf8" src="{% static 'main/js/datepicker-nl.js' %}"></script>

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ django-user-agents
 pillow>=6.0
 pygments
 requests
--e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v1.1.0-beta-11#egg=uil-django-core
+-e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v1.1.0#egg=uil-django-core
 reportlab
 docx2txt
 python-magic

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ django-user-agents
 pillow>=6.0
 pygments
 requests
--e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v1.1.0#egg=uil-django-core
+-e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v1.1.1#egg=uil-django-core
 reportlab
 docx2txt
 python-magic

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
--e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v1.1.0-beta-11#egg=uil-django-core  # via -r requirements.in
+-e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v1.1.0#egg=uil-django-core  # via -r requirements.in
 alabaster==0.7.12         # via sphinx
 arabic-reshaper==2.1.1    # via xhtml2pdf
 babel==2.9.0              # via sphinx
@@ -14,39 +14,39 @@ django-auth-ldap==2.2.0   # via -r requirements.in
 django-braces==1.14.0     # via -r requirements.in
 django-debug-toolbar==3.2  # via -r requirements.in
 django-easy-pdf==0.1.1    # via -r requirements.in
-django-impersonate==1.7.1  # via -r requirements.in
+django-impersonate==1.7.2  # via -r requirements.in
 django-modeltranslation==0.16.1  # via -r requirements.in
 django-simple-menu==1.2.1  # via -r requirements.in
 django-user-agents==0.4.0  # via -r requirements.in
-django==2.2.17            # via -r requirements.in, django-auth-ldap, django-braces, django-debug-toolbar, django-easy-pdf, django-modeltranslation, django-simple-menu, django-user-agents
+django==2.2.18            # via -r requirements.in, django-auth-ldap, django-braces, django-debug-toolbar, django-easy-pdf, django-modeltranslation, django-simple-menu, django-user-agents
 docutils==0.16            # via sphinx
 docx2txt==0.8             # via -r requirements.in
 future==0.18.2            # via arabic-reshaper
 html5lib==1.1             # via -r requirements.in, xhtml2pdf
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-jinja2==2.11.2            # via sphinx
+jinja2==2.11.3            # via sphinx
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6        # via -r requirements.in
-packaging==20.8           # via sphinx
+packaging==20.9           # via sphinx
 pbr==5.5.1                # via sphinxcontrib-apidoc
 pdftotext==2.1.5          # via -r requirements.in
-pillow==8.0.1             # via -r requirements.in, reportlab, xhtml2pdf
+pillow==8.1.0             # via -r requirements.in, reportlab, xhtml2pdf
 pyasn1-modules==0.2.8     # via python-ldap
 pyasn1==0.4.8             # via pyasn1-modules, python-ldap
-pygments==2.7.3           # via -r requirements.in, sphinx
+pygments==2.7.4           # via -r requirements.in, sphinx
 pyparsing==2.4.7          # via packaging
 pypdf2==1.26.0            # via xhtml2pdf
 python-bidi==0.4.2        # via xhtml2pdf
 python-ldap==3.3.1        # via django-auth-ldap
 python-magic==0.4.18      # via -r requirements.in
-pytz==2020.5              # via babel, django
-reportlab==3.5.56         # via -r requirements.in, django-easy-pdf, xhtml2pdf
+pytz==2021.1              # via babel, django
+reportlab==3.5.59         # via -r requirements.in, django-easy-pdf, xhtml2pdf
 requests==2.25.1          # via -r requirements.in, sphinx
 six==1.15.0               # via django-braces, django-modeltranslation, html5lib, python-bidi, xhtml2pdf
-snowballstemmer==2.0.0    # via sphinx
-sphinx-rtd-theme==0.5.0   # via -r requirements.in
-sphinx==3.4.1             # via -r requirements.in, sphinx-rtd-theme, sphinxcontrib-apidoc
+snowballstemmer==2.1.0    # via sphinx
+sphinx-rtd-theme==0.5.1   # via -r requirements.in
+sphinx==3.4.3             # via -r requirements.in, sphinx-rtd-theme, sphinxcontrib-apidoc
 sphinxcontrib-apidoc==0.3.0  # via -r requirements.in
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
@@ -57,7 +57,7 @@ sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.4.1           # via django, django-debug-toolbar
 ua-parser==0.10.0         # via user-agents
-urllib3==1.26.2           # via requests
+urllib3==1.26.3           # via requests
 user-agents==2.2.0        # via django-user-agents
 webencodings==0.5.1       # via html5lib
 xhtml2pdf==0.2.5          # via -r requirements.in, django-easy-pdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
--e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v1.1.0#egg=uil-django-core  # via -r requirements.in
+-e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v1.1.1#egg=uil-django-core  # via -r requirements.in
 alabaster==0.7.12         # via sphinx
 arabic-reshaper==2.1.1    # via xhtml2pdf
 babel==2.9.0              # via sphinx


### PR DESCRIPTION
This change makes sure we target the stable version of UiL Django Core v1.1.

There are no differences between this version and the old beta-11 version, but as we're releasing, I prefer to target the stable tag instead of the beta one.

In addition, other depenendencies have received a version bumb. Should have no breaking changes 