### PR TITLE
Fix/practice applications

### DIFF
--- a/proposals/models.py
+++ b/proposals/models.py
@@ -82,8 +82,8 @@ class Proposal(models.Model):
         (WMO_DECISION_MADE, _('Studie is beoordeeld door FETC-GW')),
     )
 
-    COURSE = '1'
-    EXPLORATION = '2'
+    COURSE = 1
+    EXPLORATION = 2
     PRACTICE_REASONS = (
         (COURSE, _('in het kader van een cursus')),
         (EXPLORATION, _('om de portal te exploreren')),

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -227,8 +227,7 @@ onderzoeker of eindverantwoordelijke bij betrokken bent.')
         return Proposal.objects.filter(
             Q(in_course=True) | Q(is_exploration=True),
             Q(applicants=self.request.user) |
-            (Q(supervisor=self.request.user) &
-             Q(status__gte=Proposal.SUBMITTED_TO_SUPERVISOR))
+            Q(supervisor=self.request.user)
         ).order_by(
             "-date_modified"
         )
@@ -728,4 +727,5 @@ class ProposalUpdatePractice(ProposalUpdate):
         """Sets in_course as a form kwarg"""
         kwargs = super(ProposalUpdatePractice, self).get_form_kwargs()
         kwargs['in_course'] = self.object.in_course
+        kwargs['is_exploration'] = self.object.is_exploration
         return kwargs


### PR DESCRIPTION
Fix to make some kind of sense of practice applications. Changed constants in `Proposal` model from strings to ints so that new proposals are actually marked as practice. Also changed `MyPracticeView` queryset to include practice applications that the user is supervising.