### PR TITLE
Some compare proposal fixes

### DIFF
--- a/main/templatetags/fetc_filters.py
+++ b/main/templatetags/fetc_filters.py
@@ -5,6 +5,10 @@ from django.contrib.auth.models import Group
 register = template.Library()
 
 
+@register.filter(name='zip')
+def zip_lists(a, b):
+  return zip(a, b)
+
 @register.filter
 def in_linguistics_chamber(current_user):
     """

--- a/main/utils.py
+++ b/main/utils.py
@@ -144,7 +144,8 @@ def get_document_contents(file: FieldFile) -> str:
             return docx2txt.process(f)
 
     if mime == 'application/vnd.openxmlformats-officedocument' \
-               '.wordprocessingml.document':
+               '.wordprocessingml.document' or \
+       mime == 'application/msword':
         with file.open(mode="rb") as f:
             return docx2txt.process(f)
 

--- a/proposals/templates/proposals/proposal_diff.html
+++ b/proposals/templates/proposals/proposal_diff.html
@@ -211,7 +211,7 @@ $(function() {
             </table>
 
             {% if proposal.wmo.status == proposal.wmo.NO_WMO or proposal.wmo.status == proposal.wmo.JUDGED %}
-            {% for study, p_study in zipped_studies %}
+            {% for study, p_study in proposal.study_set.all|zip:p_proposal.study_set.all %}
             <h2 class="mt-5 mb-1">{% trans "De deelnemers" %}</h2>
             {% include "studies/study_title.html" %}
             <table class="proposals-diff ">

--- a/proposals/templates/proposals/proposal_diff.html
+++ b/proposals/templates/proposals/proposal_diff.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load proposal_filters %}
 {% load static %}
+{% load fetc_filters %}
 
 {% block header_title %}
     {% trans "Overzicht van wijzigingen" %} - {{ block.super }}
@@ -209,7 +210,7 @@ $(function() {
                 {% endif %}
             </table>
 
-            {% if proposal.wmo.status == proposal.wmo.NO_WMO %}
+            {% if proposal.wmo.status == proposal.wmo.NO_WMO or proposal.wmo.status == proposal.wmo.JUDGED %}
             {% for study, p_study in zipped_studies %}
             <h2 class="mt-5 mb-1">{% trans "De deelnemers" %}</h2>
             {% include "studies/study_title.html" %}
@@ -373,8 +374,7 @@ $(function() {
                 </tr>
             </table>
 
-            {% for session in study.session_set.all %}
-            {% for p_session in p_study.session_set.all %}
+            {% for session, p_session in study.session_set.all|zip:p_study.session_set.all %}
             <br/>
             {% include "tasks/session_title.html" %}
             <br/>
@@ -416,8 +416,8 @@ $(function() {
                     <td>{{ session.tasks_number }}</td>
                 </tr>
             </table>
-            {% for task in session.task_set.all %}
-            {% for p_task in p_session.task_set.all %}
+
+            {% for task, p_task in session.task_set.all|zip:p_session.task_set.all %}
             <br/>
             {% include "tasks/task_title.html" %}
             <br/>
@@ -482,7 +482,6 @@ $(function() {
                 {% endif %}
             </table>
             {% endfor %}
-            {% endfor %}
 
             <h3 class="mt-5 mb-1">{% trans "Overzicht van het takenonderzoek" %}</h3>
             <table class="proposals-diff ">
@@ -498,7 +497,7 @@ $(function() {
                 </tr>
             </table>
             {% endfor %}
-            {% endfor %}
+
             {% elif study.has_sessions and not p_study.has_sessions %}
             <div class="warning">
             {% trans "De revisie bevat takenonderzoek, terwijl de originele studie dat niet bevat." %}

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -532,18 +532,6 @@ class ProposalDifference(LoginRequiredMixin, generic.DetailView):
     model = Proposal
     template_name = 'proposals/proposal_diff.html'
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-
-        obj = self.get_object()
-
-        context['zipped_studies'] = zip(
-            obj.study_set.all(),
-            obj.parent.study_set.all()
-        )
-
-        return context
-
 
 ########################
 # Preliminary assessment


### PR DESCRIPTION
Three fixes:

* Some word documents weren't seen as such, due to a missing check for the 'application/msword' mimetype
* Sessions weren't compared in proposals that have METC decision attached
* Tasks and sessions were improperly compared. (Same issue as with trajectories we had before)