### PR TITLE
Sorting fixed to prevent weird sec/sup edge case

### DIFF
--- a/reviews/templates/mail/assignment_shortroute.txt
+++ b/reviews/templates/mail/assignment_shortroute.txt
@@ -7,7 +7,7 @@ Beste {{ reviewer }},
 Er is een nieuwe aanvraag voor voortoetsing aangeboden.
 Deze aanvraag dient binnen één werkweek ({{ review_date|date:"j F Y" }}) door de FETC-GW-secretaris én één ander commissielid beoordeeld te worden.
 {% else %}{% if was_revised %}
-Er is een gereviseerde studie ter toetsing aangeboden, welke in de automatische screening de status "standaard onderzoek" heeft gekregen.  Dit betekent dat de commissie streeft om het onderzoek binnen twee weken ({{ review_date|date:"j F Y" }}) te laten beoordelen.
+Er is een gereviseerde studie ter toetsing aangeboden, welke in de automatische screening de status "standaard onderzoek" heeft gekregen. Dit betekent dat de commissie streeft om het onderzoek binnen twee weken ({{ review_date|date:"j F Y" }}) te laten beoordelen.
 {% else %}
 Er is een nieuwe studie ter toetsing aangeboden, welke in de automatische screening de status "standaard onderzoek" heeft gekregen. Dit betekent dat de commissie streeft om het onderzoek binnen twee weken ({{ review_date|date:"j F Y" }}) te beoordelen.
 {% endif %}{% endif %}

--- a/reviews/views.py
+++ b/reviews/views.py
@@ -75,7 +75,7 @@ class DecisionListView(GroupRequiredMixin, CommitteeMixin, generic.ListView):
         objects = Decision.objects.filter(
             reviewer__groups__name=settings.GROUP_SECRETARY,
             review__proposal__reviewing_committee=self.committee
-        ).order_by('-review__proposal__date_submitted')
+        ).order_by('-review__date_start')
 
         for obj in objects:
             proposal = obj.review.proposal
@@ -159,7 +159,7 @@ class DecisionMyOpenView(GroupRequiredMixin, CommitteeMixin, generic.ListView):
             reviewer__groups__name=settings.GROUP_SECRETARY,
             go='',
             review__proposal__reviewing_committee=self.committee
-        ).order_by('-review__proposal__date_submitted')
+        ).order_by('-review__date_start')
 
         for obj in objects:
             proposal = obj.review.proposal
@@ -589,7 +589,6 @@ class CreateDecisionRedirectView(LoginRequiredMixin,
                 review_id=review_pk,
             )
             decision_pk = decision.pk
-
 
         return reverse('reviews:decide', args=[decision_pk])
 


### PR DESCRIPTION
Now "assign reviewers" will overwrite the concluded supervisor review, rather than the other way around.