### PR TITLE
Changed sorting in AllProposalReviewsView

### DIFF
--- a/reviews/views.py
+++ b/reviews/views.py
@@ -297,7 +297,7 @@ class AllProposalReviewsView(UsersOrGroupsAllowedMixin,
             stage__gte=Review.ASSIGNMENT,
             proposal__status__gte=Proposal.SUBMITTED,
             proposal__reviewing_committee=self.committee,
-        ).order_by('-proposal__date_submitted')
+        ).order_by('-date_start')
 
         for obj in objects:
             proposal = obj.proposal
@@ -307,7 +307,6 @@ class AllProposalReviewsView(UsersOrGroupsAllowedMixin,
                 if reviews[proposal.pk].pk < obj.pk:
                     reviews[proposal.pk] = obj
         
-
         return [value for key, value in reviews.items()]
 
 


### PR DESCRIPTION
Proposals only appear once in this ListView, even if there are multiple reviews for that proposals. Incorrect sorting caused a completed supervisor review to overwrite a secretary review if a user fulfills both roles.