### PR TITLE
[HOTFIX] Fixed edit document link only linking to the first trajectory to master

### DIFF
--- a/reviews/templates/reviews/documents_list.html
+++ b/reviews/templates/reviews/documents_list.html
@@ -6,36 +6,32 @@
 {% load compare_tags %}
 {% load documents_list %}
 
-{% for header, items in headers_items.items %}
+{% for header, data in headers_items.items %}
 
     <h5>
        {{header}}
     </h5>
 
     <ul>
-    {% for name, file, obj in items %}
+    {% for name, file, obj, comparable in data.items %}
         <li>
             <a href="{{ file.url }}" target="_blank" download="{{file.name}}">
                 {{name}}
             </a>
-            {% if file.field.name != "pdf" %}
+            {% if comparable %}
                 {% simple_compare_link obj file %}
             {% endif %}
         </li>
     {% endfor %}
+    {% if data.edit_link %}
+        <li>
+            <a href="{{ data.edit_link }}">
+                {% trans "Documenten wijzigen" %}
+                <img src="{% static 'proposals/images/pencil.png' %}"
+                     title="{% trans 'Documenten wijzigen' %}" />
+            </a>
+        </li>
+    {% endif %}
     </ul>
 
 {% endfor %}
-
-{% if review.proposal.study_set.first %}
-
-    <p>
-        {% get_study_documents study_documents review.proposal.study_set.first %}
-        <a href="{% url 'studies:attachments' study_documents.pk %}">
-            {% trans "Documenten wijzigen" %}
-            <img src="{% static 'proposals/images/pencil.png' %}"
-                 title="{% trans 'Documenten wijzigen' %}" />
-        </a>
-    </p>
-                    
-{% endif %}

--- a/reviews/templates/reviews/documents_list.html
+++ b/reviews/templates/reviews/documents_list.html
@@ -23,15 +23,14 @@
             {% endif %}
         </li>
     {% endfor %}
-    {% if data.edit_link %}
-        <li>
-            <a href="{{ data.edit_link }}">
-                {% trans "Documenten wijzigen" %}
-                <img src="{% static 'proposals/images/pencil.png' %}"
-                     title="{% trans 'Documenten wijzigen' %}" />
-            </a>
-        </li>
-    {% endif %}
     </ul>
+
+    {% if data.edit_link %}
+    <a href="{{ data.edit_link }}">
+        {% trans "Documenten wijzigen" %}
+        <img src="{% static 'proposals/images/pencil.png' %}"
+             title="{% trans 'Documenten wijzigen' %}" />
+    </a>
+    {% endif %}
 
 {% endfor %}

--- a/reviews/templatetags/documents_list.py
+++ b/reviews/templatetags/documents_list.py
@@ -171,28 +171,32 @@ def documents_list(review):
     # Get the proposal PDF
     entries = []
     entries.append(
-        (_('Studie in PDF-vorm'), proposal.pdf, proposal)
+        # name, file, containing object, comparable
+        (_('Studie in PDF-vorm'), proposal.pdf, proposal, False)
     )
     
     # Pre-approval
     if proposal.pre_approval_pdf:
         entries.append(
-            (_('Eerdere goedkeuring'), proposal.pre_approval_pdf, proposal)
+            (_('Eerdere goedkeuring'), proposal.pre_approval_pdf, proposal, False)
         )
     
     # Pre-assessment
     if proposal.pre_assessment_pdf:
         entries.append(
-            (_('Aanvraag bij voortoetsing'), proposal.pre_assessment_pdf, proposal)
+            (_('Aanvraag bij voortoetsing'), proposal.pre_assessment_pdf, proposal, False)
         )
     
     # WMO
     if hasattr(proposal, 'wmo') and proposal.wmo.status == proposal.wmo.JUDGED:
         entries.append(
-            (_('Beslissing METC'), proposal.wmo.metc_decision_pdf, proposal.wmo)
+            (_('Beslissing METC'), proposal.wmo.metc_decision_pdf, proposal.wmo, False)
         )
     
-    headers_items[_('Aanmelding')] = entries
+    headers_items[_('Aanmelding')] = {
+        'items': entries,
+        'edit_link': None,
+    }
     
     # Now get all trajectories / extra documents
     # First we get all objects attached to a study, then we append those
@@ -228,18 +232,22 @@ def documents_list(review):
                     (
                     _('Toestemmingsdocument observatiestudie'),
                     d.study.observation.approval_document,
-                    d.study.observation,
+                    d.study.observation
                     )
                 )
         
         for (name, field, obj) in files:
             # If it's got a file in it, add an entry
             if field:
-                entries.append((name, field, obj))
+                # name, file, containing object, comparable
+                entries.append((name, field, obj, True))
         
         
         # Get a humanized name for this documents item
-        headers_items[give_name(d)] = entries
+        headers_items[give_name(d)] = {
+            'items': entries,
+            'edit_link': reverse('studies:attachments', args=[d.pk]),
+        }
     
     return {'review': review,
             'headers_items': headers_items,


### PR DESCRIPTION
The previous document edit link only allowed editting the first trajectory (well, the first document object).

This PR fixes that, by adding an edit link for every documents object.

Also changed the compare link logic a bit. 