### PR TITLE
Fix/preassessment pdf links

### DIFF
--- a/proposals/templates/proposals/vue_templates/proposal_list.html
+++ b/proposals/templates/proposals/vue_templates/proposal_list.html
@@ -66,7 +66,7 @@
             </template>
 
             <a
-                :href="proposal.pdf.url"
+                :href="$url('proposals:pdf', [proposal.pk])"
                 target="_blank"
                 :download="proposal.pdf.name"
                 v-if="proposal.pdf"

--- a/reviews/templates/reviews/vue_templates/decision_list.html
+++ b/reviews/templates/reviews/vue_templates/decision_list.html
@@ -40,7 +40,7 @@
         <template #actions="{ item: decision, context }">
             {# The :href means that we use Vue to provide the actual link. Thus, the expression is Vue code! #}
             <a
-               :href="decision.proposal.pdf.url"
+               :href="$url('proposals:pdf', [decision.proposal.pk])"
                target="_blank"
                :download="decision.proposal.pdf.name"
             >

--- a/reviews/templates/reviews/vue_templates/decision_list_reviewer.html
+++ b/reviews/templates/reviews/vue_templates/decision_list_reviewer.html
@@ -38,7 +38,11 @@
 
         <template #actions="{ item: decision, context }">
             {# The :href means that we use Vue to provide the actual link. Thus, the expression is Vue code! #}
-            <a :href="$url('proposals:pdf', [decision.proposal.pk])" target="_blank">
+            <a
+                :href="$url('proposals:pdf', [decision.proposal.pk])"
+                target="_blank"
+                :download="decision.proposal.pdf.name"
+            >
                 {# Note the absence of {% verbatim %}, we actually use django here for the image! #}
                 <img src="{{ img_pdf }}" title="{% trans 'Studie inzien' %}">
             </a>

--- a/reviews/templates/reviews/vue_templates/review_list.html
+++ b/reviews/templates/reviews/vue_templates/review_list.html
@@ -40,7 +40,7 @@
         <template #actions="{ item: review, context }">
             {# The :href means that we use Vue to provide the actual link. Thus, the expression is Vue code! #}
             <a
-               :href="review.proposal.pdf.url"
+               :href="$url('proposals:pdf', [review.proposal.pk])"
                target="_blank"
                :download="review.proposal.pdf.name"
             >


### PR DESCRIPTION
Addressess #234, and also fixes PDF links in all the other UFL Vue templates.

Note: `decision_list_reviewer.html` didn't have the `download=filename` attribute set. I'm assuming this wasn't intentional and have added it in.