### PR TITLE
Also show refnum when copying a proposal

### DIFF
--- a/proposals/field.py
+++ b/proposals/field.py
@@ -14,5 +14,13 @@ class ParentChoiceModelField(ModelChoiceField):
     def label_from_instance(self, obj: Proposal):
         last_modified = obj.date_modified.strftime("%b %d %Y %H:%M")
         if obj.is_practice():
-            return '{} ({}) (Practice)'.format(obj.title, last_modified)
-        return '{} ({})'.format(obj.title, last_modified)
+            return '{} - {} ({}) (Practice)'.format(
+                obj.reference_number,
+                obj.title,
+                last_modified
+            )
+        return '{} - {} ({})'.format(
+            obj.reference_number,
+            obj.title,
+            last_modified
+        )


### PR DESCRIPTION
This should make it easier to select the right version to copy if there
are several proposals with similar names