### PR TITLE
Fixed sort on submitted not working for supervisor reviews

### DIFF
--- a/reviews/api/serializers.py
+++ b/reviews/api/serializers.py
@@ -10,7 +10,7 @@ class InlineReviewProposalSerializer(serializers.ModelSerializer):
         model = Proposal
         fields = ['pk', 'reference_number', 'title', 'is_revision',
                   'date_confirmed', 'date_submitted', 'latest_review',
-                  'applicants', 'pdf']
+                  'applicants', 'pdf', 'date_submitted_supervisor']
         read_only_fields = fields
 
     latest_review = serializers.SerializerMethodField()

--- a/reviews/api/serializers.py
+++ b/reviews/api/serializers.py
@@ -43,7 +43,7 @@ class ReviewProposalSerializer(InlineReviewProposalSerializer):
         model = Proposal
         fields = ['pk', 'reference_number', 'title', 'is_revision',
                   'date_confirmed', 'date_submitted', 'parent', 'latest_review',
-                  'applicants', 'pdf']
+                  'applicants', 'pdf', 'date_submitted_supervisor']
         read_only_fields = fields
 
     parent = serializers.SerializerMethodField()

--- a/reviews/api/views.py
+++ b/reviews/api/views.py
@@ -271,6 +271,22 @@ class OpenSupervisorDecisionApiView(BaseDecisionApiView):
         settings.GROUP_SECRETARY,
     ]
 
+    sort_definitions = [
+        FancyListApiView.SortDefinition(
+            label=_('Referentienummer'),
+            field='proposal.reference_number',
+        ),
+        FancyListApiView.SortDefinition(
+            label=_('Datum ingediend'),
+            field='proposal.date_submitted_supervisor',
+        ),
+        FancyListApiView.SortDefinition(
+            label=_('Start datum'),
+            field='review.date_start',
+        ),
+    ]
+    default_sort = ('proposal.date_submitted_supervisor', 'desc')
+
     def get_queryset(self):
         """Returns all studies that still need to be reviewed by the secretary
         """


### PR DESCRIPTION
We were sorting on ``date_submitted``, but in these reviews this will always be None/null. We should sort on ``date_submitted_supervisor`` instead