### PR TITLE
Do not validate submit form on save_back

### DIFF
--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -578,7 +578,8 @@ class ProposalSubmitForm(forms.ModelForm):
 
         if not self.instance.is_pre_assessment and \
            not self.instance.is_practice() and \
-           not 'js-redirect-submit' in self.request.POST:
+           not 'js-redirect-submit' in self.request.POST and \
+           not 'save_back' in self.request.POST:
 
             if check_local_facilities(self.proposal) and cleaned_data[
                 'inform_local_staff'] is None:


### PR DESCRIPTION
Turns out, we were actually handling the js-redirect-url case. The 'back to prev page' button was the problem. 

This PR adds the same check js-redirect-url is using to the save_back method.