### PR TITLE
Add a download link for DMP files in the proposal pdf template

### DIFF
--- a/proposals/templates/proposals/proposal_pdf.html
+++ b/proposals/templates/proposals/proposal_pdf.html
@@ -458,7 +458,21 @@ Page <pdf:pagenumber /> of <pdf:pagecount />
             {{ extra_form_counter.increment }}
             {% endfor %}
         {% endif %}
-
+        {% if proposal.dmp_file %}
+            <h2>{% trans "Data Management Plan" %}</h2>
+            <table>
+                <tr>
+                    <th>
+                        {% get_verbose_field_name "proposals" "proposal" "dmp_file" %}
+                    </th>
+                    <td>
+                        <a href="{{ BASE_URL }}{{ proposal.dmp_file.url }}">
+                            {% trans "Download" %}
+                        </a>
+                    </td>
+                </tr>
+            </table>
+        {% endif %}
         <h2>{% trans "Aanmelding versturen" %}</h2>
         <h3>{% get_verbose_field_name "proposals" "proposal" "comments" %}</h3>
         <p>


### PR DESCRIPTION
Note: in both Firefox pdf.js and Okular links are not clickable or followable if they refer to local files on disk. So testing the link locally did not work. This goes for all download links in the proposal pdf, so testing on ACC should be fine.