### PR TITLE
fix: small bug with wrong registration pk in translation

### DIFF
--- a/studies/migrations/0038_translate_old_registrations.py
+++ b/studies/migrations/0038_translate_old_registrations.py
@@ -75,8 +75,8 @@ def translate_registrations(study, Registration):
     # as the registration type, and put the contents of the
     # Intervention.measurement into registrations_details
     if intervention:
-        # 10 is the pk of the 'other' registration
-        study.registrations.add(10)
+        # 11 is the pk of the 'other' registration
+        study.registrations.add(11)
         reg_details_dict["Intervention"] = intervention.measurement
         study.save()
 


### PR DESCRIPTION
So there was one bug left over in #904. When I added the "no registration" registration and thereby changed the pk of the "other" registration, I forgot to update how intervention registrations were translated. This PR fixes that.