### PR TITLE
fix: server-error-when-assigning-reviewers

### DIFF
--- a/reviews/templates/mail/assignment_shortroute.txt
+++ b/reviews/templates/mail/assignment_shortroute.txt
@@ -8,7 +8,7 @@ Beste {{ reviewer }},
 Er is een gereviseerde aanvraag voor voortoetsing aangeboden.
 {% else %}
 Er is een nieuwe aanvraag voor voortoetsing aangeboden.
-{% endif}
+{% endif %}
 Deze aanvraag dient binnen één werkweek ({{ review_date|date:"j F Y" }}) door de FETC-GW-secretaris én één ander commissielid beoordeeld te worden.
 {% else %}{% if was_revised %}
 Er is een gereviseerde aanvraag ter toetsing aangeboden, welke in de automatische screening de status "standaard onderzoek" heeft gekregen. Dit betekent dat de commissie streeft om het onderzoek binnen twee weken ({{ review_date|date:"j F Y" }}) te laten beoordelen.


### PR DESCRIPTION
fixes #1031 

Problem was in the short route only.

There is a chance review was still being assigned and only the mail was not being send.