### PR TITLE
fix: lock bpython<0.25 + update dependencies

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: psf/black@stable
+      - uses: psf/black@25.11.0
         with:
           src: .
 

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ requests
 cdh-django-core[core,federated-auth,vue,mail,files,rest,recommended] @ git+https://github.com/CentreForDigitalHumanities/django-shared-core.git@v3.2.0-alpha.0
 python-magic
 pdftotext
-bpython
+bpython<0.26
 black
 djlint
 sentry-sdk[django]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,20 +10,20 @@ alabaster==0.7.16
     # via sphinx
 arabic-reshaper==3.0.0
     # via xhtml2pdf
-asgiref==3.11.0
+asgiref==3.11.1
     # via django
 asn1crypto==1.5.1
     # via
     #   oscrypto
     #   pyhanko
     #   pyhanko-certvalidator
-babel==2.17.0
+babel==2.18.0
     # via sphinx
 black==25.11.0
     # via -r requirements.in
-blessed==1.25.0
+blessed==1.30.0
     # via curtsies
-bpython==0.26
+bpython==0.25
     # via
     #   -r requirements.in
     #   cdh-django-core
@@ -70,7 +70,7 @@ defusedxml==0.7.1
     #   pysaml2
 deprecated==1.3.1
     # via cdh-django-core
-django==4.2.27
+django==4.2.28
     # via
     #   -r requirements.in
     #   cdh-django-core
@@ -174,11 +174,11 @@ mysqlclient==1.4.6
     # via -r requirements.in
 oscrypto==1.3.0
     # via pyhanko-certvalidator
-packaging==25.0
+packaging==26.0
     # via
     #   black
     #   sphinx
-pathspec==1.0.3
+pathspec==1.0.4
     # via
     #   black
     #   djlint
@@ -208,17 +208,17 @@ pygments==2.19.2
     #   -r requirements.in
     #   bpython
     #   sphinx
-pyhanko==0.32.0
+pyhanko==0.33.0
     # via xhtml2pdf
-pyhanko-certvalidator==0.29.0
+pyhanko-certvalidator==0.29.1
     # via
     #   pyhanko
     #   xhtml2pdf
-pyjwt==2.10.1
+pyjwt==2.11.0
     # via cdh-django-core
 pyopenssl==24.2.1
     # via pysaml2
-pypdf==6.6.0
+pypdf==6.7.0
     # via xhtml2pdf
 pysaml2==7.5.4
     # via djangosaml2
@@ -232,7 +232,7 @@ python-magic==0.4.27
     # via
     #   -r requirements.in
     #   cdh-django-core
-pytokens==0.3.0
+pytokens==0.4.1
     # via black
 pyxdg==0.28
     # via bpython
@@ -240,9 +240,9 @@ pyyaml==6.0.3
     # via
     #   djlint
     #   pyhanko
-regex==2025.11.3
+regex==2026.1.15
     # via djlint
-reportlab==4.4.7
+reportlab==4.4.10
     # via
     #   svglib
     #   xhtml2pdf
@@ -257,7 +257,7 @@ requests==2.32.5
     #   sphinx
 rlpycairo==0.4.0
     # via svglib
-sentry-sdk[django]==2.49.0
+sentry-sdk[django]==2.52.0
     # via -r requirements.in
 six==1.17.0
     # via
@@ -310,7 +310,7 @@ tomli==2.4.0
     #   black
     #   djlint
     #   sphinx
-tqdm==4.67.1
+tqdm==4.67.3
     # via djlint
 typing-extensions==4.15.0
     # via
@@ -336,14 +336,14 @@ user-agents==2.2.0
     # via django-user-agents
 vbuild==0.8.2
     # via cdh-django-core
-wcwidth==0.2.14
+wcwidth==0.6.0
     # via blessed
 webencodings==0.5.1
     # via
     #   cssselect2
     #   html5lib
     #   tinycss2
-wrapt==2.0.1
+wrapt==2.1.1
     # via deprecated
 xhtml2pdf==0.2.17
     # via -r requirements.in


### PR DESCRIPTION
fixes #1035.

Bpython's newest version crashes shell_plus because we use Python 3.9. This fixes that.

Also updated other dependencies. 

Edit:

I am also just noticing that black@stable, no longer supports python 3.9. So I had to update the pr-checks as well. Maybe time to move away from 3.9?